### PR TITLE
use curl instead of netcat for broker healthcheck

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -187,7 +187,7 @@ services:
       MFA_WEBAUTHN_apiKey: not_needed_here
       MFA_WEBAUTHN_apiSecret: not_needed_here
     healthcheck:
-      test: nc -vz localhost 80
+      test: curl --connect-timeout 5 http://localhost:80/site/status
       start_period: 1s
       interval: 1s
       timeout: 5s


### PR DESCRIPTION
[ITSE-1081](https://support.gtis.sil.org/issue/ITSE-1081) where possible, replace whenavail with health checks

---

### Changed
- Use curl rather than netcat for the broker health check. In the PHP container, netcat is installed only for whenavail. If we can remove both, that would be better.
