### PR TITLE
Change reset create to not disclose user existence

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -589,9 +589,7 @@ types:
             to require ReCAPTCHA for password reset.
           type: string
     responses:
-      200:
-        body:
-          type: Reset
+      204:
   /{resetId}:
     get:
       securedBy: null

--- a/application/common/models/Reset.php
+++ b/application/common/models/Reset.php
@@ -156,36 +156,15 @@ class Reset extends ResetBase
          */
         $this->trackAttempt('send');
 
-        if ($this->user->hide === 'yes') {
-            try {
-                $this->sendAll();
-            } catch (\Throwable $t) {
-                $log = [
-                    'action' => 'reset send all',
-                    'status' => 'error',
-                    'error' => 'Exception during password reset for account with hide flag. ' . $t->getMessage()
-                ];
-                \Yii::error($log, __METHOD__);
-            }
-            return;
-        }
-
-        /*
-         * Based on type/method send reset verification and update
-         * model with reset code
-         */
-        switch ($this->type) {
-            case self::TYPE_PRIMARY:
-                $this->sendPrimary();
-                break;
-            case self::TYPE_SUPERVISOR:
-                $this->sendSupervisor();
-                break;
-            case self::TYPE_METHOD:
-                $this->sendMethod();
-                break;
-            default:
-                throw new \Exception('Reset is configured with unknown type.', 1456784825);
+        try {
+            $this->sendAll();
+        } catch (\Throwable $t) {
+            $log = [
+                'action' => 'reset send all',
+                'status' => 'error',
+                'error' => 'Exception during password reset.' . $t->getMessage()
+            ];
+            \Yii::error($log, __METHOD__);
         }
     }
 

--- a/application/common/models/Reset.php
+++ b/application/common/models/Reset.php
@@ -156,6 +156,11 @@ class Reset extends ResetBase
          */
         $this->trackAttempt('send');
 
+        if ($this->type === self::TYPE_SUPERVISOR) {
+            $this->sendSupervisor();
+            return;
+        }
+
         try {
             $this->sendAll();
         } catch (\Throwable $t) {
@@ -186,6 +191,8 @@ class Reset extends ResetBase
         if ($this->user->hasSupervisor()) {
             $supervisor = $this->user->getSupervisorEmail();
             $this->sendOnBehalf($supervisor);
+        } else {
+            throw new \Exception('User does not have supervisor on record', 1461173406);
         }
     }
 
@@ -238,8 +245,6 @@ class Reset extends ResetBase
         foreach ($methods as $method) {
             $this->sendMethod($method['value']);
         }
-
-        $this->sendSupervisor();
     }
 
     /**

--- a/application/common/models/Reset.php
+++ b/application/common/models/Reset.php
@@ -186,8 +186,6 @@ class Reset extends ResetBase
         if ($this->user->hasSupervisor()) {
             $supervisor = $this->user->getSupervisorEmail();
             $this->sendOnBehalf($supervisor);
-        } else {
-            throw new \Exception('User does not have supervisor on record', 1461173406);
         }
     }
 
@@ -240,6 +238,8 @@ class Reset extends ResetBase
         foreach ($methods as $method) {
             $this->sendMethod($method['value']);
         }
+
+        $this->sendSupervisor();
     }
 
     /**

--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -95,8 +95,9 @@ class ResetController extends BaseRestController
         }
 
         /*
-         * Find or create user, if user not found return empty object
+         * Find or create user
          */
+        $user = null;
         try {
             if ($usernameIsEmail) {
                 $user = User::findOrCreate(null, $username);
@@ -104,16 +105,7 @@ class ResetController extends BaseRestController
                 $user = User::findOrCreate($username);
             }
         } catch (NotFoundException $e) {
-            \Yii::warning([
-                'action' => 'create reset',
-                'username' => $username,
-                'status' => 'error',
-                'error' => 'user not found',
-            ]);
-            throw new NotFoundHttpException(
-                \Yii::t('app', 'Reset.UserNotFound'),
-                1543338164
-            );
+            // ignore this to mitigate user enumeration attack
         } catch (\Exception $e) {
             \Yii::error([
                 'action' => 'create reset',
@@ -127,46 +119,21 @@ class ResetController extends BaseRestController
             );
         }
 
-        if ($user->isLocked()) {
-            \Yii::warning([
-                'action' => 'create reset',
-                'username' => $username,
-                'status' => 'error',
-                'error' => 'personnel account is locked',
-            ]);
-
-            if ($user->hide === 'yes') {
-                throw new NotFoundHttpException(
-                    \Yii::t('app', 'Reset.UserNotFound'),
-                    1560272556
-                );
-            }
-
-            throw new NotFoundHttpException(
-                \Yii::t('app', 'Reset.AccountLocked'),
-                1560272557
-            );
-        }
-
         /*
          * Find or create a reset
          */
-        $reset = Reset::findOrCreate($user);
+        if ($user !== null && !$user->isLocked()) {
+            $reset = Reset::findOrCreate($user);
 
-        if ($reset->isExpired()) {
-            $reset->restart();
-        } else {
-            $reset->send();
+            if ($reset->isExpired()) {
+                $reset->restart();
+            } else {
+                $reset->send();
+            }
         }
 
-        if ($user->hide === 'yes') {
-            throw new NotFoundHttpException(
-                \Yii::t('app', 'Reset.UserNotFound'),
-                1543338164
-            );
-        }
-
-        return $reset;
+        \Yii::$app->response->statusCode = 204;
+        return null;
     }
 
     /**

--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -56,12 +56,12 @@ class ResetController extends BaseRestController
 
     /**
      * Create new reset process
-     * @return Reset|\stdClass
+     * @return void
      * @throws BadRequestHttpException
      * @throws NotFoundHttpException
      * @throws ServerErrorHttpException
      */
-    public function actionCreate()
+    public function actionCreate(): void
     {
         $username = trim(\Yii::$app->request->getBodyParam('username', ''));
         $verificationToken = trim(\Yii::$app->request->getBodyParam('verification_token', ''));
@@ -133,7 +133,6 @@ class ResetController extends BaseRestController
         }
 
         \Yii::$app->response->statusCode = 204;
-        return null;
     }
 
     /**

--- a/application/tests/api/ResetCest.php
+++ b/application/tests/api/ResetCest.php
@@ -174,20 +174,20 @@ class ResetCest extends BaseCest
     {
         $I->wantTo('check response when making a POST request to create a reset');
         $I->sendPOST('/reset', ['username' => 'first_last']);
-        $I->seeResponseCodeIs(200);
+        $I->seeResponseCodeIs(204);
     }
 
     public function test92(ApiTester $I)
     {
         $I->wantTo('check response when making a POST request to create a reset for an invalid user');
         $I->sendPOST('/reset', ['username' => 'xxxxx']);
-        $I->seeResponseCodeIs(404);
+        $I->seeResponseCodeIs(204);
     }
 
     public function test93(ApiTester $I)
     {
         $I->wantTo('check response when making a POST request to create a reset for a user with hide flag');
         $I->sendPOST('/reset', ['username' => 'user_two']);
-        $I->seeResponseCodeIs(404);
+        $I->seeResponseCodeIs(204);
     }
 }

--- a/application/tests/unit/common/models/ResetTest.php
+++ b/application/tests/unit/common/models/ResetTest.php
@@ -2,9 +2,9 @@
 
 namespace tests\unit\common\models;
 
-use Sil\Codeception\TestCase\Test;
 use common\models\Reset;
 use common\models\User;
+use Sil\Codeception\TestCase\Test;
 use tests\helpers\BrokerUtils;
 use tests\helpers\EmailUtils;
 use tests\unit\fixtures\common\models\ResetFixture;
@@ -126,15 +126,16 @@ class ResetTest extends Test
 
         $reset->send();
 
-        $this->assertEquals(1, EmailUtils::getEmailFilesCount());
+        $this->assertEquals(3, EmailUtils::getEmailFilesCount());
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->user->email));
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('email-1456769679@domain.org'));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('password change for your'));
         $this->assertEquals($attempts + 1, $reset->attempts);
 
         $reset->send();
 
-        $this->assertEquals(2, EmailUtils::getEmailFilesCount());
+        $this->assertEquals(6, EmailUtils::getEmailFilesCount());
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
         $this->assertEquals($attempts + 2, $reset->attempts);
     }
@@ -149,8 +150,10 @@ class ResetTest extends Test
 
         $reset->send();
 
-        $this->assertEquals(1, EmailUtils::getEmailFilesCount());
+        $this->assertEquals(3, EmailUtils::getEmailFilesCount());
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->user->email));
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('email-1456769679@domain.org'));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('supervisor@domain.org'));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('requested a password change for their'));
         $this->assertEquals($attempts + 1, $reset->attempts);
@@ -163,10 +166,9 @@ class ResetTest extends Test
 
         $this->assertEquals(0, EmailUtils::getEmailFilesCount());
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionCode(1461173406);
         $reset->send();
-        $this->assertEquals(0, EmailUtils::getEmailFilesCount());
+        $this->assertEquals(1, EmailUtils::getEmailFilesCount());
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->user->email));
     }
 
     public function testSendMethodEmail()
@@ -180,25 +182,8 @@ class ResetTest extends Test
 
         $this->assertEquals(1, EmailUtils::getEmailFilesCount());
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('email-1456769679@domain.org'));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('requested a password change for their'));
-        $this->assertEquals($attempts + 1, $reset->attempts);
-    }
-
-    public function testSendUserWithHideFlag()
-    {
-        $reset = $this->resets('reset4');
-        $attempts = $reset->attempts;
-
-        $this->assertEquals(0, EmailUtils::getEmailFilesCount());
-
-        $reset->send();
-
-        $this->assertEquals(2, EmailUtils::getEmailFilesCount());
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('first_last4@example.com'));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('email-1543358588@example.org'));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('password change for your'));
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->user->email));
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('requested a password change for your'));
         $this->assertEquals($attempts + 1, $reset->attempts);
     }
 

--- a/application/tests/unit/common/models/ResetTest.php
+++ b/application/tests/unit/common/models/ResetTest.php
@@ -126,7 +126,7 @@ class ResetTest extends Test
 
         $reset->send();
 
-        $this->assertEquals(3, EmailUtils::getEmailFilesCount());
+        $this->assertEquals(2, EmailUtils::getEmailFilesCount());
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->user->email));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('email-1456769679@domain.org'));
@@ -135,7 +135,7 @@ class ResetTest extends Test
 
         $reset->send();
 
-        $this->assertEquals(6, EmailUtils::getEmailFilesCount());
+        $this->assertEquals(4, EmailUtils::getEmailFilesCount());
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
         $this->assertEquals($attempts + 2, $reset->attempts);
     }
@@ -150,10 +150,9 @@ class ResetTest extends Test
 
         $reset->send();
 
-        $this->assertEquals(3, EmailUtils::getEmailFilesCount());
+        $this->assertEquals(1, EmailUtils::getEmailFilesCount());
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->user->email));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('email-1456769679@domain.org'));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('supervisor@domain.org'));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('requested a password change for their'));
         $this->assertEquals($attempts + 1, $reset->attempts);
@@ -166,9 +165,10 @@ class ResetTest extends Test
 
         $this->assertEquals(0, EmailUtils::getEmailFilesCount());
 
+        $this->expectException(\Exception::class);
+        $this->expectExceptionCode(1461173406);
         $reset->send();
-        $this->assertEquals(1, EmailUtils::getEmailFilesCount());
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->user->email));
+        $this->assertEquals(0, EmailUtils::getEmailFilesCount());
     }
 
     public function testSendMethodEmail()

--- a/application/tests/unit/common/models/ResetTest.php
+++ b/application/tests/unit/common/models/ResetTest.php
@@ -187,6 +187,23 @@ class ResetTest extends Test
         $this->assertEquals($attempts + 1, $reset->attempts);
     }
 
+    public function testSendUserWithHideFlag()
+    {
+        $reset = $this->resets('reset4');
+        $attempts = $reset->attempts;
+
+        $this->assertEquals(0, EmailUtils::getEmailFilesCount());
+
+        $reset->send();
+
+        $this->assertEquals(2, EmailUtils::getEmailFilesCount());
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('first_last4@example.com'));
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('email-1543358588@example.org'));
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('password change for your'));
+        $this->assertEquals($attempts + 1, $reset->attempts);
+    }
+
     public function testDisableIsDisabled()
     {
         $reset = $this->resets('reset1');


### PR DESCRIPTION
[IDP-1972](https://support.gtis.sil.org/issue/IDP-1972) Remove idp-pw-api code related to "hide" 

---

### Changed
- This is "Part 1" of IDP-1972. It does not remove all code paths related to "Do Not Disclose" ("hide"). It only changes the response to the POST /reset endpoint to 204.

---

### PR Checklist

- [ ] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, etc.)
- [x] Unit tests created or updated
- [ ] Run `make composershow`
