### PR TITLE
Release 9.2.3 - fix reset to not email supervisor unless necessary

### DIFF
--- a/application/common/models/Reset.php
+++ b/application/common/models/Reset.php
@@ -161,7 +161,7 @@ class Reset extends ResetBase
         }
 
         $methods = Method::getVerifiedMethods($this->user->employee_id);
-        if ($methods !== null && $this->user->hasSupervisor()) {
+        if (empty($methods) && $this->user->hasSupervisor()) {
             $this->sendPrimary();
             $this->sendSupervisor();
             return;

--- a/application/tests/helpers/BrokerFakeData.php
+++ b/application/tests/helpers/BrokerFakeData.php
@@ -18,7 +18,7 @@ return [
         'email' => 'first_last2@domain.com',
         'employee_id' => '222222',
         'username' => 'first2_last2',
-        'manager_email' => null,
+        'manager_email' => 'supervisor2@example.com',
         'hide' => 'no',
     ],
     [

--- a/application/tests/unit/common/models/ResetTest.php
+++ b/application/tests/unit/common/models/ResetTest.php
@@ -120,7 +120,7 @@ class ResetTest extends Test
 
     public function testSendPrimaryNoMethods()
     {
-        $reset = $this->resets('reset1');
+        $reset = $this->resets('reset2');
         $attempts = $reset->attempts;
 
         $this->assertEquals(0, EmailUtils::getEmailFilesCount());
@@ -130,7 +130,7 @@ class ResetTest extends Test
         $this->assertEquals(2, EmailUtils::getEmailFilesCount());
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->user->email));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('supervisor@domain.org'));
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('supervisor2@example.com'));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('password change for your'));
         $this->assertEquals($attempts + 1, $reset->attempts);
 
@@ -209,7 +209,7 @@ class ResetTest extends Test
 
     public function testSendSupervisorNoSupervisor()
     {
-        $reset = $this->resets('reset2');
+        $reset = $this->resets('reset3');
         $reset->type = Reset::TYPE_SUPERVISOR;
 
         $this->assertEquals(0, EmailUtils::getEmailFilesCount());
@@ -249,7 +249,7 @@ class ResetTest extends Test
         $this->assertEquals(2, EmailUtils::getEmailFilesCount());
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('first_last4@example.com'));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('supervisor4@example.com'));
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('email-1543358588@example.org'));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('password change for your'));
         $this->assertEquals($attempts + 1, $reset->attempts);
     }

--- a/application/tests/unit/common/models/ResetTest.php
+++ b/application/tests/unit/common/models/ResetTest.php
@@ -2,6 +2,7 @@
 
 namespace tests\unit\common\models;
 
+use common\models\Method;
 use common\models\Reset;
 use common\models\User;
 use Sil\Codeception\TestCase\Test;
@@ -153,6 +154,31 @@ class ResetTest extends Test
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->user->email));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('email-777@example.org'));
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('password change for your'));
+        $this->assertEquals($attempts + 1, $reset->attempts);
+
+        $reset->send();
+
+        $this->assertEquals(4, EmailUtils::getEmailFilesCount());
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
+        $this->assertEquals($attempts + 2, $reset->attempts);
+    }
+
+    public function testSendPrimaryWithMethodsWithSupervisor()
+    {
+        $reset = $this->resets('reset1');
+        $attempts = $reset->attempts;
+
+        $this->assertEquals(0, EmailUtils::getEmailFilesCount());
+
+        $reset->send();
+
+        $this->assertEquals(2, EmailUtils::getEmailFilesCount());
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->user->email));
+        $methods = Method::getVerifiedMethods($reset->user->employee_id);
+        $this->assertNotEmpty($methods);
+        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($methods[0]['value']));
         $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('password change for your'));
         $this->assertEquals($attempts + 1, $reset->attempts);
 


### PR DESCRIPTION
[IDP-1997](https://support.gtis.sil.org/issue/IDP-1997) Forgot Password isn't emailing recovery address

---

### Fixed
- Fixed reset emailing supervisor instead of password recovery emails.

---

### PR Checklist

- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, etc.)
- [ ] Unit tests created or updated
- [ ] Run `make composershow`
