### PR TITLE
Release 10.0.0-pre.1 -- Remove the "type" property on the Reset model

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -588,52 +588,6 @@ types:
     responses:
       204:
   /{resetId}:
-    get:
-      securedBy: null
-      description: Request the reset object by its id.
-      responses:
-        200:
-          body:
-            type: Reset
-    put:
-      securedBy: null
-      description: >
-        Update the reset to use a different email. If `type` is `email`,
-        then this request is for an alternate recovery Method, and
-        `methodId` is required.
-      body:
-        properties:
-          type:
-            enum: [ primary, supervisor, email ]
-          methodId?: string
-      responses:
-        200:
-          body:
-            type: Reset
-        400:
-          description: >
-            The reset `type` was not provided or is not valid, or the
-            `methodId` parameter was not provided when required.
-          body:
-            type: Error
-        404:
-          description: >
-            The reset could not be found or the referenced Method has
-            not been verified.
-          body:
-            type: Error
-    /resend:
-      put:
-        securedBy: null
-        description: Request to resend verification email.
-        responses:
-          200:
-            body:
-              type: Reset
-          404:
-            description: Reset could not be found.
-            body:
-              type: Error
     /validate:
       put:
         securedBy: null

--- a/api.raml
+++ b/api.raml
@@ -573,7 +573,7 @@ types:
     description: |
       Initiate a password reset.
       Sends reset email to primary email address with a link like
-      `https://idp-pw.local/#/recovery/verify/{resetUid}/{code}`
+      `https://idp-pw.local/#/recovery/verify/{resetUuid}/0`
       Responds with id of reset object and all available email addresses
       for the user.
     body:
@@ -591,7 +591,7 @@ types:
     /validate:
       put:
         securedBy: null
-        description: Validate reset code to complete password reset process
+        description: Validate reset UUID to complete password reset process
         body:
           properties:
             code: string
@@ -599,9 +599,6 @@ types:
           200:
             description: >
               Reset was validated. Subsequent API calls will use a http only cookie for the access token.
-          400:
-            description: >
-              The provided code was incorrect.
           410:
             description: >
               The code has expired.

--- a/api.raml
+++ b/api.raml
@@ -573,7 +573,7 @@ types:
     description: |
       Initiate a password reset.
       Sends reset email to primary email address with a link like
-      `https://idp-pw.local/#/recovery/verify/{resetUuid}/0`
+      `https://idp-pw.local/#/recovery/verify/{resetUid}/{code}`
       Responds with id of reset object and all available email addresses
       for the user.
     body:
@@ -591,7 +591,7 @@ types:
     /validate:
       put:
         securedBy: null
-        description: Validate reset UUID to complete password reset process
+        description: Validate reset code to complete password reset process
         body:
           properties:
             code: string
@@ -599,6 +599,9 @@ types:
           200:
             description: >
               Reset was validated. Subsequent API calls will use a http only cookie for the access token.
+          400:
+            description: >
+              The provided code was incorrect.
           410:
             description: >
               The code has expired.

--- a/application/common/models/Reset.php
+++ b/application/common/models/Reset.php
@@ -5,7 +5,6 @@ namespace common\models;
 use common\helpers\Utils;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Json;
-use yii\web\BadRequestHttpException;
 use yii\web\ServerErrorHttpException;
 use yii\web\TooManyRequestsHttpException;
 
@@ -16,10 +15,6 @@ use yii\web\TooManyRequestsHttpException;
  */
 class Reset extends ResetBase
 {
-    public const TYPE_PRIMARY = 'primary'; // Used for primary email address
-    public const TYPE_METHOD = 'method';
-    public const TYPE_SUPERVISOR = 'supervisor';
-
     public const TOPIC_RESET_EMAIL_SENT = 'Reset Email Sent';
     public const TOPIC_RESET_PHONE_SENT = 'Reset Phone Sent';
 
@@ -48,14 +43,6 @@ class Reset extends ResetBase
 
                 [
                     ['attempts'], 'default', 'value' => 0,
-                ],
-
-                [
-                    ['type'], 'in', 'range' => [
-                        self::TYPE_PRIMARY, self::TYPE_METHOD, self::TYPE_SUPERVISOR,
-                    ],
-                    'message' => 'Reset type must be either ' . self::TYPE_PRIMARY . ' or ' . self::TYPE_METHOD
-                        . ' or ' . self::TYPE_SUPERVISOR . ' .',
                 ],
 
                 [
@@ -95,7 +82,6 @@ class Reset extends ResetBase
             'action' => 'findOrCreate reset',
             'user_id' => $user->id,
             'user' => $user->email,
-            'type' => self::TYPE_PRIMARY,
             'ip_address' => 'initiated outside web request context',
         ];
 
@@ -114,11 +100,6 @@ class Reset extends ResetBase
              */
             $reset = new Reset();
             $reset->user_id = $user->id;
-            /*
-             * Only set type/method if creating so that on subsequent restarts of process
-             * it does not reset method to primary
-             */
-            $reset->type = self::TYPE_PRIMARY;
 
             /*
              * Save new Reset
@@ -126,13 +107,8 @@ class Reset extends ResetBase
             $reset->saveOrError('create new reset', \Yii::t('app', 'Reset.CreateFailure'));
 
             $log['reset_id'] = $reset->id;
-            $log['type'] = $reset->type;
         } else {
             $log['existing reset'] = 'yes';
-            /*
-             * change method back to primary if they are requesting to start reset again
-             */
-            $reset->setType(self::TYPE_PRIMARY);
         }
 
         $log['status'] = 'success';
@@ -154,11 +130,6 @@ class Reset extends ResetBase
          * Track attempt and throw error if disabled or limit is reached
          */
         $this->trackAttempt('send');
-
-        if ($this->type === self::TYPE_SUPERVISOR) {
-            $this->sendSupervisor();
-            return;
-        }
 
         $methods = Method::getVerifiedMethods($this->user->employee_id);
         if ($methods !== null && $this->user->hasSupervisor()) {
@@ -306,12 +277,7 @@ class Reset extends ResetBase
          * Track attempt and throw error if disabled or limit is reached
          */
         $this->trackAttempt('verify');
-
-        if ($this->isTypeEmail()) {
-            return Verification::isEmailCodeValid($this->code, $userProvided);
-        } else {
-            throw new \Exception('Unable to verify code because method type is invalid', 1462543005);
-        }
+        return Verification::isEmailCodeValid($this->code, $userProvided);
     }
 
     /**
@@ -325,17 +291,6 @@ class Reset extends ResetBase
         $this->expires = self::calculateExpireTime();
         $this->saveOrError('restart reset');
         $this->send();
-    }
-
-    /**
-     * Check if reset is using an email type of verification
-     * @return bool
-     */
-    public function isTypeEmail()
-    {
-        return ($this->type === self::TYPE_PRIMARY
-            || $this->type === self::TYPE_SUPERVISOR
-            || $this->type === self::TYPE_METHOD);
     }
 
     /**
@@ -397,7 +352,6 @@ class Reset extends ResetBase
             'reset_id' => $this->id,
             'attempts' => $this->attempts,
             'user' => $this->user->email,
-            'type' => $this->type,
             'disable_until' => $this->disable_until,
             'status' => 'success',
         ];
@@ -422,7 +376,6 @@ class Reset extends ResetBase
             'action' => 'enable reset',
             'reset_id' => $this->id,
             'status' => 'success',
-            'type' => $this->type,
             'user' => $this->user->email,
         ]);
     }
@@ -453,64 +406,6 @@ class Reset extends ResetBase
                 $this->disable();
             }
         }
-    }
-
-    public function setType($type, $methodUid = null)
-    {
-        $previousType = $this->type;
-        /*
-         * If type is not method, update or throw error
-         */
-        if (in_array($type, [self::TYPE_SUPERVISOR, self::TYPE_PRIMARY])) {
-            $this->type = $type;
-            $this->email = null;
-        } elseif ($type == self::TYPE_METHOD || $type == Method::TYPE_EMAIL) {
-            /*
-             * Method::TYPE_EMAIL is included because that type is identified by the UI
-             */
-
-            /*
-             * If type is method but methodId is missing, throw error
-             */
-            if ($methodUid === null) {
-                throw new BadRequestHttpException(
-                    \Yii::t('app', 'Reset.MissingMethodUID'),
-                    1462988984
-                );
-            }
-
-            /*
-             * Make sure user owns requested method and it is verified before update
-             */
-            $method = Method::getOneVerifiedMethod($methodUid, $this->user->employee_id);
-            $this->type = self::TYPE_METHOD;
-            $this->email = $method['value'];
-        } else {
-            throw new BadRequestHttpException(
-                \Yii::t('app', 'Reset.UnknownType'),
-                1462989489
-            );
-        }
-
-        // NOTE: We stopped changing the code here so that, if someone requests
-        // a subsequent reset while an existing one is not yet expired, the same
-        // code will be used. That way, clicking the link in the first email
-        // will still work.
-
-        /*
-         * Save changes
-         */
-        $this->saveOrError('Set type of reset', \Yii::t('app', 'Reset.UpdateTypeError'));
-
-        \Yii::info([
-            'action' => 'change reset',
-            'attempts' => $this->attempts,
-            'previous_type' => $previousType,
-            'reset_id' => $this->id,
-            'status' => 'success',
-            'type' => $this->type,
-            'user' => $this->user->email,
-        ]);
     }
 
     /**

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -132,14 +132,9 @@ return [
                 /*
                  * Reset routes
                  */
-                'GET /reset/' . UID_ROUTE_PATTERN => 'reset/view',
                 'POST /reset' => 'reset/create',
-                'PUT /reset/' . UID_ROUTE_PATTERN => 'reset/update',
-                'PUT /reset/' . UID_ROUTE_PATTERN . '/resend' => 'reset/resend',
                 'PUT /reset/' . UID_ROUTE_PATTERN . '/validate' => 'reset/validate',
                 'OPTIONS /reset' => 'reset/options',
-                'OPTIONS /reset/' . UID_ROUTE_PATTERN => 'reset/options',
-                'OPTIONS /reset/' . UID_ROUTE_PATTERN . '/resend' => 'reset/options',
                 'OPTIONS /reset/' . UID_ROUTE_PATTERN . '/validate' => 'reset/options',
 
                 /*

--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -40,21 +40,6 @@ class ResetController extends BaseRestController
     }
 
     /**
-     * @param String $uid
-     * @return Reset
-     * @throws NotFoundHttpException
-     */
-    public function actionView($uid)
-    {
-        $reset = Reset::findOne(['uid' => $uid]);
-        if ($reset === null) {
-            throw new NotFoundHttpException();
-        }
-
-        return $reset;
-    }
-
-    /**
      * Create new reset process
      * @return void
      * @throws BadRequestHttpException
@@ -133,71 +118,6 @@ class ResetController extends BaseRestController
         }
 
         \Yii::$app->response->statusCode = 204;
-    }
-
-    /**
-     * Update reset type/method and send verification
-     * @param string $uid
-     * @return Reset
-     * @throws BadRequestHttpException
-     * @throws NotFoundHttpException
-     * @throws \Exception
-     * @throws \yii\web\ServerErrorHttpException
-     * @throws \yii\web\TooManyRequestsHttpException
-     */
-    public function actionUpdate($uid)
-    {
-        /** @var Reset $reset */
-        $reset = Reset::findOne(['uid' => $uid]);
-        if ($reset === null) {
-            throw new NotFoundHttpException(
-                \Yii::t('app', 'Reset.NotFound'),
-                1462989590
-            );
-        }
-
-        $type = \Yii::$app->request->getBodyParam('type', null);
-        $methodId = \Yii::$app->request->getBodyParam('id', null);
-
-        if ($type === null) {
-            throw new BadRequestHttpException(
-                \Yii::t('app', 'Reset.MissingResetType'),
-                1462989664
-            );
-        }
-
-        /*
-         * Update type
-         */
-        $reset->setType($type, $methodId);
-
-        /*
-         * Send verification
-         */
-        $reset->send();
-
-        return $reset;
-    }
-
-    /**
-     * @param string $uid
-     * @return Reset
-     * @throws NotFoundHttpException
-     */
-    public function actionResend($uid)
-    {
-        /** @var Reset $reset */
-        $reset = Reset::findOne(['uid' => $uid]);
-        if ($reset === null) {
-            throw new NotFoundHttpException();
-        }
-
-        /*
-         * Resend verification
-         */
-        $reset->send();
-
-        return $reset;
     }
 
     /**

--- a/application/tests/api/ResetCest.php
+++ b/application/tests/api/ResetCest.php
@@ -41,66 +41,6 @@ class ResetCest extends BaseCest
         $I->seeResponseCodeIs(200);
     }
 
-    public function test3(ApiTester $I)
-    {
-        $I->wantTo('check response when making authenticated GET request to /reset');
-        $I->setCookie('access_token', 'user1', parent::getCookieConfig());
-        $I->sendGET('/reset/11111111111111111111111111111111');
-        $I->seeResponseCodeIs(405);
-        $I->seeResponseContainsJson([
-            'name' => 'Method Not Allowed',
-        ]);
-    }
-
-    public function test4(ApiTester $I)
-    {
-        $I->wantTo('check response when making unauthenticated GET request to /reset');
-        $I->sendGET('/reset/11111111111111111111111111111111');
-        $I->seeResponseCodeIs(401);
-        $I->seeResponseContainsJson([
-            'name' => 'Unauthorized',
-        ]);
-    }
-
-    public function test6(ApiTester $I)
-    {
-        $I->wantTo('check response when making unauthenticated PUT request to /reset');
-        $I->sendPUT('/reset/11111111111111111111111111111111', [
-            'type' => 'supervisor',
-        ]);
-        $I->seeResponseCodeIs(401);
-    }
-
-    public function test62(ApiTester $I)
-    {
-        $I->wantTo('check response when making authenticated DELETE request to /reset/id');
-        $I->setCookie('access_token', 'user1', parent::getCookieConfig());
-        $I->sendDELETE('/reset/11111111111111111111111111111111');
-        $I->seeResponseCodeIs(405);
-    }
-
-    public function test63(ApiTester $I)
-    {
-        $I->wantTo('check response when making unauthenticated DELETE request to /reset/id');
-        $I->sendDELETE('/reset/11111111111111111111111111111111');
-        $I->seeResponseCodeIs(401);
-    }
-
-    public function test7(ApiTester $I)
-    {
-        $I->wantTo('check response when making unauthenticated PUT request to /reset');
-        $I->sendPUT('/reset/11111111111111111111111111111111/resend');
-        $I->seeResponseCodeIs(401);
-    }
-
-    public function test72(ApiTester $I)
-    {
-        $I->wantTo('check response when making authenticated PUT request to /reset');
-        $I->setCookie('access_token', 'user1', parent::getCookieConfig());
-        $I->sendPUT('/reset/11111111111111111111111111111111/resend');
-        $I->seeResponseCodeIs(405);
-    }
-
     public function test8(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated PUT request to validate a reset code');

--- a/application/tests/api/ResetCest.php
+++ b/application/tests/api/ResetCest.php
@@ -43,51 +43,32 @@ class ResetCest extends BaseCest
 
     public function test3(ApiTester $I)
     {
-        $I->wantTo('check response when making authenticated GET request for obtaining reset object');
+        $I->wantTo('check response when making authenticated GET request to /reset');
         $I->setCookie('access_token', 'user1', parent::getCookieConfig());
         $I->sendGET('/reset/11111111111111111111111111111111');
-        $I->seeResponseCodeIs(200);
+        $I->seeResponseCodeIs(405);
         $I->seeResponseContainsJson([
-            'uid' => "11111111111111111111111111111111",
-            'methods' => [
-                'type' => "primary",
-                'value' => "f****_l**t@o***********.o**",
-            ],
+            'name' => 'Method Not Allowed',
         ]);
     }
 
     public function test4(ApiTester $I)
     {
-        $I->wantTo('check response when making unauthenticated GET request for obtaining reset object and verify methods are masked out');
+        $I->wantTo('check response when making unauthenticated GET request to /reset');
         $I->sendGET('/reset/11111111111111111111111111111111');
-        $I->seeResponseCodeIs(200);
+        $I->seeResponseCodeIs(401);
         $I->seeResponseContainsJson([
-            'uid' => "11111111111111111111111111111111",
-            'methods' => [
-                'type' => "primary",
-                'value' => "f****_l**t@o***********.o**",
-            ],
+            'name' => 'Unauthorized',
         ]);
-    }
-
-    public function test5(ApiTester $I)
-    {
-        $I->wantTo('check response when making PUT request for updating a reset object method');
-        $I->sendPUT('/reset/11111111111111111111111111111111', [
-            'uid' => '22222222222222222222222222222222',
-            'type' => 'phone',
-            'value' => '###-###-4567',
-        ]);
-        $I->seeResponseCodeIs(400); // phone reset is not supported
     }
 
     public function test6(ApiTester $I)
     {
-        $I->wantTo('check response when making PUT request for updating a reset object method supervisor');
+        $I->wantTo('check response when making unauthenticated PUT request to /reset');
         $I->sendPUT('/reset/11111111111111111111111111111111', [
             'type' => 'supervisor',
         ]);
-        $I->seeResponseCodeIs(200);
+        $I->seeResponseCodeIs(401);
     }
 
     public function test62(ApiTester $I)
@@ -107,17 +88,17 @@ class ResetCest extends BaseCest
 
     public function test7(ApiTester $I)
     {
-        $I->wantTo('check response when making unauthenticated PUT request to resend the reset');
+        $I->wantTo('check response when making unauthenticated PUT request to /reset');
         $I->sendPUT('/reset/11111111111111111111111111111111/resend');
-        $I->seeResponseCodeIs(200);
+        $I->seeResponseCodeIs(401);
     }
 
     public function test72(ApiTester $I)
     {
-        $I->wantTo('check response when making authenticated PUT request to resend the verification');
+        $I->wantTo('check response when making authenticated PUT request to /reset');
         $I->setCookie('access_token', 'user1', parent::getCookieConfig());
         $I->sendPUT('/reset/11111111111111111111111111111111/resend');
-        $I->seeResponseCodeIs(200);
+        $I->seeResponseCodeIs(405);
     }
 
     public function test8(ApiTester $I)

--- a/application/tests/unit/common/models/ResetTest.php
+++ b/application/tests/unit/common/models/ResetTest.php
@@ -98,16 +98,6 @@ class ResetTest extends Test
         $this->assertEquals($existing->id, $new->id);
     }
 
-    public function testFindOrCreateExistingResetTypeToPrimary()
-    {
-        $existing = $this->resets('reset1');
-        $existing->setType(Reset::TYPE_SUPERVISOR);
-
-        $new = Reset::findOrCreate($existing->user);
-        $this->assertEquals($existing->id, $new->id);
-        $this->assertEquals(Reset::TYPE_PRIMARY, $new->type);
-    }
-
     public function testIsUserProvidedCodeCorrect()
     {
         $reset = $this->resets('reset3');
@@ -163,54 +153,6 @@ class ResetTest extends Test
         $this->assertEquals($attempts + 2, $reset->attempts);
     }
 
-    public function testSendSupervisorHasSupervisor()
-    {
-        $reset = $this->resets('reset1');
-        $reset->type = Reset::TYPE_SUPERVISOR;
-        $attempts = $reset->attempts;
-
-        $this->assertEquals(0, EmailUtils::getEmailFilesCount());
-
-        $reset->send();
-
-        $this->assertEquals(1, EmailUtils::getEmailFilesCount());
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->user->email));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('supervisor@domain.org'));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('requested a password change for their'));
-        $this->assertEquals($attempts + 1, $reset->attempts);
-    }
-
-    public function testSendSupervisorNoSupervisor()
-    {
-        $reset = $this->resets('reset2');
-        $reset->type = Reset::TYPE_SUPERVISOR;
-
-        $this->assertEquals(0, EmailUtils::getEmailFilesCount());
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionCode(1461173406);
-        $reset->send();
-        $this->assertEquals(0, EmailUtils::getEmailFilesCount());
-    }
-
-    public function testSendMethodEmail()
-    {
-        $reset = $this->resets('reset3');
-        $attempts = $reset->attempts;
-
-        $this->assertEquals(0, EmailUtils::getEmailFilesCount());
-
-        $reset->send();
-
-        $this->assertEquals(2, EmailUtils::getEmailFilesCount());
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->code));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated($reset->user->email));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('email-777@example.org'));
-        $this->assertTrue(EmailUtils::hasEmailFileBeenCreated('requested a password change for your'));
-        $this->assertEquals($attempts + 1, $reset->attempts);
-    }
-
     public function testDisableIsDisabled()
     {
         $reset = $this->resets('reset1');
@@ -220,21 +162,6 @@ class ResetTest extends Test
         $reset->disable();
         $this->assertTrue($reset->isDisabled());
         $this->assertEqualsWithDelta($expireDate, strtotime($reset->disable_until), 2, '');
-    }
-
-    public function testSetType()
-    {
-        $reset = $this->resets('reset1');
-        $this->assertEquals(Reset::TYPE_PRIMARY, $reset->type);
-
-        $reset->setType(Reset::TYPE_SUPERVISOR);
-        $this->assertEquals(Reset::TYPE_SUPERVISOR, $reset->type);
-
-        $reset->setType(Reset::TYPE_METHOD, '22222222222222222222222222222222');
-        $this->assertEquals(Reset::TYPE_METHOD, $reset->type);
-
-        $reset->setType(Reset::TYPE_PRIMARY);
-        $this->assertEquals(Reset::TYPE_PRIMARY, $reset->type);
     }
 
     public function testTrackAttempt()
@@ -264,15 +191,6 @@ class ResetTest extends Test
     {
         $reset = $this->resets('reset1');
         $this->assertEquals('f****_l**t@o***********.o**', $reset->getMaskedValue());
-
-        $reset->setType(Reset::TYPE_SUPERVISOR);
-        $this->assertEquals('s********r@d*****.o**', $reset->getMaskedValue());
-
-        $reset->setType(Reset::TYPE_METHOD, '22222222222222222222222222222222');
-
-        $reset = Reset::findOne(['id' => $reset->id]);
-
-        $this->assertEquals('e**************9@d*****.o**', $reset->getMaskedValue());
     }
 
 }


### PR DESCRIPTION
[IDP-1856](https://support.gtis.sil.org/issue/IDP-1856) Make Do Not Disclose the standard, then remove unnecessary code

---

### Removed
- Due to the ambiguity intentionally added to the password reset flow, there is no reason to keep the concept of a reset "type". All available password reset email addresses (except supervisor) are used every time instead of letting the user choose which one to use at the time of recovery. This PR doesn't fully remove the database column or the model attribute, but removes all means to change the attribute.
- Removed the `GET /reset/{uid}` and `PUT /reset/{uid}/resend` endpoints. These are no longer in use due the simpler reset flow. There is no use in retrieving the reset as there is no useful metadata available, and a re-send is done by repeating the `POST /reset` request.

---

### PR Checklist

- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, etc.)
- [x] Unit tests created or updated
- [ ] Run `make composershow`
