### PR TITLE
Release 10.0.0-pre.2 - use Reset endpoints in idp-id-broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,13 +190,13 @@ Returns configuration parameters supplied by environment variables.
 
 This endpoint verifies connectivity to the database.
 
-#### `POST /reset` and `PUT /reset/{uid}/validate`
+#### `POST /reset` and `PUT /reset/{uuid}/validate`
 
 This combination requires connection to a PasswordStore component and a Personnel
 component containing a valid user record. After sending the `POST`, retrieve the reset
-code from the email or the database, and the reset uid from the response body, then
-supply them in the `PUT` request body and URI. The response will contain an
-`access_token` to use for subsequent calls that require it.
+UUID from the user via the password reset email message, then supply it in the `PUT`
+request URI. The response will contain a Set-Cookie header to use for subsequent calls
+to set a new password.
 
 #### `GET /auth/login`
 

--- a/api.raml
+++ b/api.raml
@@ -573,7 +573,7 @@ types:
     description: |
       Initiate a password reset.
       Sends reset email to primary email address with a link like
-      `https://idp-pw.local/#/recovery/verify/{resetUid}/{code}`
+      `https://idp-pw.local/#/recovery/verify/{resetUuid}/0`
       Responds with id of reset object and all available email addresses
       for the user.
     body:
@@ -591,7 +591,7 @@ types:
     /validate:
       put:
         securedBy: null
-        description: Validate reset code to complete password reset process
+        description: Validate reset UUID to complete password reset process
         body:
           properties:
             code: string
@@ -599,9 +599,6 @@ types:
           200:
             description: >
               Reset was validated. Subsequent API calls will use a http only cookie for the access token.
-          400:
-            description: >
-              The provided code was incorrect.
           410:
             description: >
               The code has expired.

--- a/application/composer.json
+++ b/application/composer.json
@@ -17,7 +17,7 @@
     "yiisoft/yii2-gii": "*",
     "sil-org/php-env": "^2.1.1 || ^3.0",
     "sil-org/yii2-json-log-targets": "^2.0",
-    "sil-org/idp-id-broker-php-client": "^4.3.0",
+    "sil-org/idp-id-broker-php-client": "^4.10",
     "sil-org/zxcvbn-api-client-php": "^2.0",
     "simplesamlphp/saml2": "^4",
     "google/apiclient": "^2.0",

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1bc05cfa85cccbbed6c1c01951de921",
+    "content-hash": "4cc3aedaf5f40a272362573548095c5a",
     "packages": [
         {
             "name": "behat/gherkin",
@@ -7895,16 +7895,16 @@
         },
         {
             "name": "sil-org/idp-id-broker-php-client",
-            "version": "4.9.0",
+            "version": "4.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sil-org/idp-id-broker-php-client.git",
-                "reference": "8f395f3ee7ac6eec439796abf399ede1802c0501"
+                "reference": "89bc67a2cf7385710f6281233ff5281cd8550cd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sil-org/idp-id-broker-php-client/zipball/8f395f3ee7ac6eec439796abf399ede1802c0501",
-                "reference": "8f395f3ee7ac6eec439796abf399ede1802c0501",
+                "url": "https://api.github.com/repos/sil-org/idp-id-broker-php-client/zipball/89bc67a2cf7385710f6281233ff5281cd8550cd5",
+                "reference": "89bc67a2cf7385710f6281233ff5281cd8550cd5",
                 "shasum": ""
             },
             "require": {
@@ -7915,7 +7915,7 @@
             },
             "require-dev": {
                 "behat/behat": "^3.3",
-                "phpunit/phpunit": "^8.0"
+                "webmozart/assert": "^1.12"
             },
             "type": "library",
             "autoload": {
@@ -7944,9 +7944,9 @@
             ],
             "support": {
                 "issues": "https://github.com/sil-org/idp-id-broker-php-client/issues",
-                "source": "https://github.com/sil-org/idp-id-broker-php-client/tree/4.9.0"
+                "source": "https://github.com/sil-org/idp-id-broker-php-client/tree/4.10.0"
             },
-            "time": "2025-10-15T04:27:43+00:00"
+            "time": "2026-05-14T08:24:42+00:00"
         },
         {
             "name": "sil-org/php-env",
@@ -12334,5 +12334,5 @@
         "ext-pdo": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/application/dependencies.json
+++ b/application/dependencies.json
@@ -429,7 +429,7 @@
   },
   {
     "name": "sil-org/idp-id-broker-php-client",
-    "version": "4.9.0"
+    "version": "4.10.0"
   },
   {
     "name": "sil-org/php-env",

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -133,9 +133,9 @@ return [
                  * Reset routes
                  */
                 'POST /reset' => 'reset/create',
-                'PUT /reset/' . UID_ROUTE_PATTERN . '/validate' => 'reset/validate',
+                'PUT /reset/<uuid>/validate' => 'reset/validate',
                 'OPTIONS /reset' => 'reset/options',
-                'OPTIONS /reset/' . UID_ROUTE_PATTERN . '/validate' => 'reset/options',
+                'OPTIONS /reset/<uuid>/validate' => 'reset/options',
 
                 /*
                  * User  routes

--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -4,19 +4,41 @@ namespace frontend\controllers;
 
 use common\components\personnel\NotFoundException;
 use common\helpers\Utils;
-use common\models\Reset;
 use common\models\User;
+use Exception;
 use frontend\components\BaseRestController;
+use Sil\Idp\IdBroker\Client\IdBrokerClient;
+use Sil\Idp\IdBroker\Client\ServiceException;
+use Yii;
 use yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
-use yii\helpers\Json;
 use yii\web\BadRequestHttpException;
 use yii\web\HttpException;
-use yii\web\NotFoundHttpException;
-use yii\web\ServerErrorHttpException;
 
 class ResetController extends BaseRestController
 {
+    public IdBrokerClient $idBrokerClient;
+
+    /**
+     * @throws Exception
+     */
+    public function init(): void
+    {
+        parent::init();
+        $config = Yii::$app->params['idBrokerConfig'];
+        if (empty($config['baseUrl']) || empty($config['accessToken'])) {
+            throw new Exception('ID_BROKER_baseURL and ID_BROKER_accessToken are required', 1778752282);
+        }
+        $this->idBrokerClient = new IdBrokerClient(
+            $config['baseUrl'],
+            $config['accessToken'],
+            [
+                IdBrokerClient::TRUSTED_IPS_CONFIG => $config['validIpRanges'] ?? [],
+                IdBrokerClient::ASSERT_VALID_BROKER_IP_CONFIG => $config['assertValidBrokerIp'] ?? true,
+            ]
+        );
+    }
+
     /**
      * Access Control Filter
      * NEEDS TO BE UPDATED FOR EVERY ACTION
@@ -40,19 +62,19 @@ class ResetController extends BaseRestController
     }
 
     /**
-     * Create new reset process
+     * Create new password reset. Calls the ID Broker to request a new Reset record and send one or more email
+     * messages containing a link to click, which will direct the user to the Validate action in this controller.
      * @return void
      * @throws BadRequestHttpException
-     * @throws NotFoundHttpException
-     * @throws ServerErrorHttpException
+     * @throws ServiceException
      */
     public function actionCreate(): void
     {
-        $username = trim(\Yii::$app->request->getBodyParam('username', ''));
-        $verificationToken = trim(\Yii::$app->request->getBodyParam('verification_token', ''));
+        $username = trim(Yii::$app->request->getBodyParam('username', ''));
+        $verificationToken = trim(Yii::$app->request->getBodyParam('verification_token', ''));
 
         if ($username === '') {
-            throw new BadRequestHttpException(\Yii::t('app', 'Reset.MissingUsername'));
+            throw new BadRequestHttpException(Yii::t('app', 'Reset.MissingUsername'));
         }
 
         /*
@@ -60,153 +82,47 @@ class ResetController extends BaseRestController
          * This will throw an exception if not successful, checking response to
          * be double sure an exception is thrown.
          */
-        if (\Yii::$app->params['recaptcha']['required']) {
+        if (Yii::$app->params['recaptcha']['required']) {
             if ($verificationToken === '') {
-                throw new BadRequestHttpException(\Yii::t('app', 'Reset.MissingRecaptchaCode'));
+                throw new BadRequestHttpException(Yii::t('app', 'Reset.MissingRecaptchaCode'));
             }
 
-            $clientIp = Utils::getClientIp(\Yii::$app->request);
+            $clientIp = Utils::getClientIp(Yii::$app->request);
             if (!Utils::isRecaptchaResponseValid($verificationToken, $clientIp)) {
-                throw new BadRequestHttpException(\Yii::t('app', 'Reset.RecaptchaFailedVerification'));
+                throw new BadRequestHttpException(Yii::t('app', 'Reset.RecaptchaFailedVerification'));
             }
         }
 
-        /*
-         * Check if $username looks like an email address
-         */
-        $usernameIsEmail = false;
-        if (substr_count($username, '@')) {
-            $usernameIsEmail = true;
-        }
+        $this->idBrokerClient->createReset($username);
 
-        /*
-         * Find or create user
-         */
-        $user = null;
+        Yii::$app->response->statusCode = 204;
+    }
+
+    /**
+     * Validate reset code. If successful, a limited-access cookie will be set.
+     * @param string $uuid
+     * @return void
+     * @throws HttpException
+     * @throws NotFoundException
+     * @throws Exception
+     */
+    public function actionValidate(string $uuid): void
+    {
         try {
-            if ($usernameIsEmail) {
-                $user = User::findOrCreate(null, $username);
-            } else {
-                $user = User::findOrCreate($username);
-            }
-        } catch (NotFoundException $e) {
-            // ignore this to mitigate user enumeration attack
-        } catch (\Exception $e) {
-            \Yii::error([
-                'action' => 'create reset',
-                'username' => $username,
-                'status' => 'error',
-                'error' => $e->getMessage(),
-            ]);
-            throw new ServerErrorHttpException(
-                \Yii::t('app', 'Reset.CreateFailure'),
-                1469036552
-            );
+            $brokerResponse = $this->idBrokerClient->verifyReset($uuid);
+        } catch (ServiceException $e) {
+            throw new HttpException($e->httpStatusCode);
         }
 
-        /*
-         * Find or create a reset
-         */
-        if ($user !== null && !$user->isLocked()) {
-            $reset = Reset::findOrCreate($user);
+        $user = User::findOrCreate(null, null, $brokerResponse['employee_id']);
 
-            if ($reset->isExpired()) {
-                $reset->restart();
-            } else {
-                $reset->send();
-            }
-        }
+        $user->createAccessToken(User::AUTH_TYPE_RESET);
 
-        \Yii::$app->response->statusCode = 204;
-    }
-
-    /**
-     * Validate reset code. Logs user in if successful
-     * @param string $uid
-     * @return null
-     * @throws BadRequestHttpException
-     * @throws NotFoundHttpException
-     * @throws ServerErrorHttpException
-     * @throws \Exception
-     * @throws \Throwable
-     */
-    public function actionValidate($uid)
-    {
-        /** @var Reset $reset */
-        $reset = Reset::findOne(['uid' => $uid]);
-        if ($reset === null) {
-            throw new NotFoundHttpException();
-        }
-
-        $log = [
-            'action' => 'Validate reset',
-            'reset_id' => $reset->id,
-            'type' => $reset->type,
-            'user' => $reset->user->email,
-        ];
-
-        if ($reset->isUserProvidedCodeCorrect($this->getCodeFromRequestBody())) {
-            if ($reset->isExpired()) {
-                $reset->restart();
-                throw new HttpException(410);
-            }
-
-            $ipAddress = Utils::getClientIp(\Yii::$app->request);
-
-            $log['attempts'] = $reset->attempts;
-            $log['ip_address'] = $ipAddress;
-            $log['method_value'] = $reset->getMaskedValue();
-            $log['status'] = 'success';
-
-            /*
-             * Reset verified successfully, create access token for user
-             */
-            try {
-                $reset->user->createAccessToken(User::AUTH_TYPE_RESET);
-
-                \Yii::info($log);
-
-                /*
-                 * Delete reset record, log errors, but let user proceed
-                 */
-                if (!$reset->delete()) {
-                    \Yii::warning([
-                        'action' => 'delete reset after validation',
-                        'reset_id' => $reset->id,
-                        'status' => 'error',
-                        'error' => Json::encode($reset->getFirstErrors()),
-                    ]);
-                }
-                return null;
-
-            } catch (\Exception $e) {
-                $log['status'] = 'error';
-                $log['error'] = 'Unable to log user in after successful reset verification';
-                \Yii::error($log);
-                throw $e;
-            }
-        }
-
-        $log['attempts'] = $reset->attempts;
-        $log['status'] = 'error';
-        $log['error'] = 'Reset code verification failed';
-        \Yii::warning($log);
-        throw new BadRequestHttpException(
-            \Yii::t('app', 'Reset.InvalidCode'),
-            1462991098
-        );
-    }
-
-    /**
-     * @return string
-     * @throws BadRequestHttpException
-     */
-    protected function getCodeFromRequestBody(): string
-    {
-        $code = trim(\Yii::$app->request->getBodyParam('code', ''));
-        if ($code === '') {
-            throw new BadRequestHttpException(\Yii::t('app', 'Reset.MissingCode'), 1462989866);
-        }
-        return $code;
+        Yii::info([
+        'action' => 'Validate reset',
+            'status' => 'success',
+            'employee_id' => $user->employee_id,
+            'ip_address' => Utils::getClientIp(Yii::$app->request),
+        ]);
     }
 }

--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -119,7 +119,7 @@ class ResetController extends BaseRestController
         $user->createAccessToken(User::AUTH_TYPE_RESET);
 
         Yii::info([
-        'action' => 'Validate reset',
+            'action' => 'Validate reset',
             'status' => 'success',
             'employee_id' => $user->employee_id,
             'ip_address' => Utils::getClientIp(Yii::$app->request),

--- a/application/tests/api/ResetCest.php
+++ b/application/tests/api/ResetCest.php
@@ -41,54 +41,34 @@ class ResetCest extends BaseCest
         $I->seeResponseCodeIs(200);
     }
 
-    public function test8(ApiTester $I)
+    public function test800(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated PUT request to validate a reset code');
-        $I->sendPUT('/reset/33333333333333333333333333333333/validate', ['code' => '333']);
+        $I->sendPUT('/reset/11111111111111111111111111111111/validate');
         $I->seeResponseCodeIs(200);
     }
 
-    public function test81(ApiTester $I)
+    public function test810(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated PUT request to validate an expired reset code');
-        $I->sendPUT('/reset/33333333333333333333333333333334/validate', ['code' => '444']);
+        $I->sendPUT('/reset/22222222222222222222222222222222/validate');
         $I->seeResponseCodeIs(410);
     }
 
-    public function test812(ApiTester $I)
-    {
-        $I->wantTo('check response on unauthenticated PUT request to validate an expired, incorrect reset code');
-        $I->sendPUT('/reset/33333333333333333333333333333334/validate', ['code' => 'xxx']);
-        $I->seeResponseCodeIs(400);
-    }
-
-    public function test82(ApiTester $I)
+    public function test820(ApiTester $I)
     {
         $I->wantTo('check response when making authenticated PUT request to validate a reset code');
         $I->setCookie('access_token', 'user1', parent::getCookieConfig());
-        $I->sendPUT('/reset/33333333333333333333333333333333/validate', ['code' => '333']);
+        $I->sendPUT('/reset/33333333333333333333333333333333/validate');
         $I->seeResponseCodeIs(200);
     }
 
-    public function test83(ApiTester $I)
+    public function test830(ApiTester $I)
     {
         $I->wantTo('check response when making authenticated DELETE request to reset/id/validate');
         $I->setCookie('access_token', 'user1', parent::getCookieConfig());
-        $I->sendDELETE('/reset/33333333333333333333333333333333/validate', ['code' => '333']);
+        $I->sendDELETE('/reset/44444444444444444444444444444444/validate');
         $I->seeResponseCodeIs(405);
-    }
-
-    public function test9(ApiTester $I)
-    {
-        $I->wantTo('check response when making multiple authenticated PUT request to validate a reset code');
-        for ($i = 0; $i < 10; $i++) {
-            $I->sendPUT('/reset/33333333333333333333333333333334/validate', ['code' => '344']);
-            if ($i < 9) {
-                $I->seeResponseCodeIs(400);
-            } else {
-                $I->seeResponseCodeIs(429);
-            }
-        }
     }
 
     public function test91(ApiTester $I)

--- a/compose.yaml
+++ b/compose.yaml
@@ -166,6 +166,7 @@ services:
       - ./dockerbuild/broker/m381901_235959_insert_test_data.php:/app/console/migrations/m381901_235959_insert_test_data.php
       - ./dockerbuild/broker/User.php:/app/console/migrations/User.php
       - ./dockerbuild/broker/Method.php:/app/console/migrations/Method.php
+      - ./dockerbuild/broker/Reset.php:/app/console/migrations/Reset.php
     environment:
       EMAILER_CLASS: \Sil\SilIdBroker\Behat\Context\fakes\FakeEmailer
       IDP_NAME: idp1

--- a/compose.yaml
+++ b/compose.yaml
@@ -155,7 +155,7 @@ services:
       PMA_PASSWORD: broker
 
   broker:
-    image: ghcr.io/sil-org/idp-id-broker:8
+    image: ghcr.io/sil-org/idp-id-broker:verify-reset
     platform: linux/amd64
     ports:
       - "51154:80"

--- a/dockerbuild/broker/Reset.php
+++ b/dockerbuild/broker/Reset.php
@@ -1,0 +1,34 @@
+<?php
+
+use common\helpers\MySqlDateTime;
+
+return [
+    'reset1' => [
+        'id' => 1,
+        'uuid' => '11111111111111111111111111111111',
+        'user_id' => 1,
+        'expires' => MySqlDateTime::relativeTime('+1 hour'),
+        'created' => MySqlDateTime::now(),
+    ],
+    'reset2' => [
+        'id' => 2,
+        'uuid' => '22222222222222222222222222222222',
+        'user_id' => 2,
+        'expires' => MySqlDateTime::now(),
+        'created' => MySqlDateTime::now(),
+    ],
+    'reset3' => [
+        'id' => 3,
+        'uuid' => '33333333333333333333333333333333',
+        'user_id' => 3,
+        'expires' => MySqlDateTime::relativeTime('+1 hour'),
+        'created' => MySqlDateTime::now(),
+    ],
+    'reset4' => [
+        'id' => 4,
+        'uuid' => '44444444444444444444444444444444',
+        'user_id' => 4,
+        'expires' => MySqlDateTime::relativeTime('+1 hour'),
+        'created' => MySqlDateTime::now(),
+    ],
+];

--- a/dockerbuild/broker/m381901_235959_insert_test_data.php
+++ b/dockerbuild/broker/m381901_235959_insert_test_data.php
@@ -44,6 +44,14 @@ class m381901_235959_insert_test_data extends Migration
             array_keys($methodData['method2']),
             $methodData
         );
+
+        $resetData = require(__DIR__ . '/Reset.php');
+
+        $this->batchInsert(
+            '{{reset}}',
+            array_keys($resetData['reset2']),
+            $resetData
+        );
     }
 
     /**


### PR DESCRIPTION
[IDP-1968](https://support.gtis.sil.org/issue/IDP-1968) remove reset table from idp-pw-api

---

### Changed (BREAKING)
- Use the password reset endpoints in idp-id-broker version 8.5.0 (pending release) rather than the local table.

---

### PR Checklist

- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] Documentation (README, etc.)
- [x] Unit tests created or updated
- [x] Run `make composershow`
