### PR TITLE
corrections suggested in PR 365 feedback

### DIFF
--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -67,7 +67,7 @@ class ResetController extends BaseRestController
      * messages containing a link to click, which will direct the user to the Validate action in this controller.
      * @return void
      * @throws BadRequestHttpException
-     * @throws ServiceException
+     * @throws HttpException
      */
     public function actionCreate(): void
     {
@@ -94,7 +94,11 @@ class ResetController extends BaseRestController
             }
         }
 
-        $this->idBrokerClient->createReset($username);
+        try {
+            $this->idBrokerClient->createReset($username);
+        } catch (ServiceException $e) {
+            throw new HttpException($e->httpStatusCode);
+        }
 
         Yii::$app->response->statusCode = 204;
     }

--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -51,12 +51,13 @@ class ResetController extends BaseRestController
                 'rules' => [
                     [
                         'allow' => true,
-                        'roles' => ['?'],
+                        'actions' => ['create', 'validate'],
+                        'roles' => ['@', '?'],
                     ],
                 ],
             ],
             'authenticator' => [
-                'only' => [''], // Bypass authentication for all actions
+                'optional' => ['create', 'validate'], // bypass authentication for specified routes
             ],
         ]);
     }

--- a/application/tests/api/ResetCest.php
+++ b/application/tests/api/ResetCest.php
@@ -43,21 +43,21 @@ class ResetCest extends BaseCest
 
     public function test800(ApiTester $I)
     {
-        $I->wantTo('check response when making unauthenticated PUT request to validate a reset code');
+        $I->wantTo('check response when making unauthenticated PUT request to validate a reset UUID');
         $I->sendPUT('/reset/11111111111111111111111111111111/validate');
         $I->seeResponseCodeIs(200);
     }
 
     public function test810(ApiTester $I)
     {
-        $I->wantTo('check response when making unauthenticated PUT request to validate an expired reset code');
+        $I->wantTo('check response when making unauthenticated PUT request to validate an expired reset UUID');
         $I->sendPUT('/reset/22222222222222222222222222222222/validate');
         $I->seeResponseCodeIs(404);
     }
 
     public function test820(ApiTester $I)
     {
-        $I->wantTo('check response when making authenticated PUT request to validate a reset code');
+        $I->wantTo('check response when making authenticated PUT request to validate a reset UUID');
         $I->setCookie('access_token', 'user1', parent::getCookieConfig());
         $I->sendPUT('/reset/33333333333333333333333333333333/validate');
         $I->seeResponseCodeIs(200);
@@ -65,7 +65,7 @@ class ResetCest extends BaseCest
 
     public function test830(ApiTester $I)
     {
-        $I->wantTo('check response when making authenticated DELETE request to reset/id/validate');
+        $I->wantTo('check response when making authenticated DELETE request to reset/{uuid}/validate');
         $I->setCookie('access_token', 'user1', parent::getCookieConfig());
         $I->sendDELETE('/reset/44444444444444444444444444444444/validate');
         $I->seeResponseCodeIs(405);
@@ -82,6 +82,14 @@ class ResetCest extends BaseCest
     {
         $I->wantTo('check response when making a POST request to create a reset for an invalid user');
         $I->sendPOST('/reset', ['username' => 'xxxxx']);
+        $I->seeResponseCodeIs(204);
+    }
+
+    public function test93(ApiTester $I)
+    {
+        $I->wantTo('check response when making an authenticated POST request to create a reset');
+        $I->setCookie('access_token', 'user1', parent::getCookieConfig());
+        $I->sendPOST('/reset', ['username' => 'first_last']);
         $I->seeResponseCodeIs(204);
     }
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -155,7 +155,7 @@ services:
       PMA_PASSWORD: broker
 
   broker:
-    image: ghcr.io/sil-org/idp-id-broker:verify-reset
+    image: ghcr.io/sil-org/idp-id-broker:8
     platform: linux/amd64
     ports:
       - "51154:80"


### PR DESCRIPTION
[IDP-1968](https://support.gtis.sil.org/issue/IDP-1968) remove reset table from idp-pw-api

---

### Fixed
- Make the ResetController authentication more explicit, specifying the actions by name.
- Mimic the id-broker http response status for the POST /reset endpoint.
- Added a test case for authenticated reset validation request.
- Use the released idp-id-broker tag in compose.yaml rather than the branch-based `verify-reset` tag.

---

### PR Checklist

- [ ] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, etc.)
- [ ] Unit tests created or updated
- [ ] Run `make composershow`
