### PR TITLE
remove the method_id foreign key as suggested in PR #366

### DIFF
--- a/application/console/migrations/m260518_000000_remove_reset_table.php
+++ b/application/console/migrations/m260518_000000_remove_reset_table.php
@@ -29,7 +29,6 @@ class m260518_000000_remove_reset_table extends Migration
             "ENGINE=InnoDB DEFAULT CHARSET=utf8"
         );
         $this->addForeignKey('fk_reset_user_id', '{{reset}}', 'user_id', '{{user}}', 'id', 'CASCADE', 'NO ACTION');
-        $this->addForeignKey('fk_reset_method_id', '{{reset}}', 'method_id', '{{method}}', 'id', 'CASCADE', 'NO ACTION');
         $this->createIndex('uq_reset_uid', '{{reset}}', 'uid', true);
         $this->createIndex('uq_reset_user_id', '{{reset}}', 'user_id', true);
         $this->createIndex('uq_reset_code', '{{reset}}', 'code', false);


### PR DESCRIPTION
[IDP-1968](https://support.gtis.sil.org/issue/IDP-1968) remove reset table from idp-pw-api

---

### Fixed
- As suggested in #366, fixed the down migration to not attempt to create a foreign key on the method_id since that column was removed in an earlier migration.

---

### PR Checklist

- [ ] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, etc.)
- [ ] Unit tests created or updated
- [ ] Run `make composershow`
