### PR TITLE
PR 2 of 3: Access-token flow – update AuthController logout to use IdBroker

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -69,7 +69,7 @@ class User implements IdentityInterface, Arrayable
      * @param PersonnelUser $personnelUser
      * @return self
      */
-    public static function createFromPersonnelUser(PersonnelUser $personnelUser): self
+    public static function constructFromPersonnelUser(PersonnelUser $personnelUser): self
     {
         $user = new self();
         $user->uuid = $personnelUser->uuid;
@@ -211,7 +211,7 @@ class User implements IdentityInterface, Arrayable
             );
         }
 
-        return self::createFromPersonnelUser($personnelUser);
+        return self::constructFromPersonnelUser($personnelUser);
     }
 
     /**
@@ -286,7 +286,7 @@ class User implements IdentityInterface, Arrayable
         try {
             $personnel = self::getPersonnelComponent();
             $personnelUser = $personnel->findByEmployeeId($id);
-            return self::createFromPersonnelUser($personnelUser);
+            return self::constructFromPersonnelUser($personnelUser);
         } catch (\Exception $e) {
             return null;
         }
@@ -306,7 +306,7 @@ class User implements IdentityInterface, Arrayable
         try {
             $personnel = self::getPersonnelComponent();
             $personnelUser = $personnel->findByAccessToken($hash);
-            return self::createFromPersonnelUser($personnelUser);
+            return self::constructFromPersonnelUser($personnelUser);
         } catch (NotFoundException $e) {
             return null;
         } catch (\Exception $e) {
@@ -576,7 +576,7 @@ class User implements IdentityInterface, Arrayable
         $personnel = self::getPersonnelComponent();
         try {
             $personnelUser = $personnel->findByInvite($inviteCode);
-            return self::createFromPersonnelUser($personnelUser);
+            return self::constructFromPersonnelUser($personnelUser);
         } catch (NotFoundException $e) {
             return null;
         }

--- a/application/frontend/controllers/AuthController.php
+++ b/application/frontend/controllers/AuthController.php
@@ -2,9 +2,9 @@
 
 namespace frontend\controllers;
 
+use common\components\auth\AuthnInterface;
 use common\components\auth\RedirectException;
 use common\components\auth\User as AuthUser;
-use common\components\auth\AuthnInterface;
 use common\components\personnel\NotFoundException;
 use common\helpers\Utils;
 use common\models\User;
@@ -125,31 +125,34 @@ class AuthController extends BaseRestController
             /*
              * Look up and clear the token in IdBroker, then log out of IdP
              */
-            try {
                 $accessTokenHash = Utils::getAccessTokenHash($accessToken);
                 /** @var \common\components\personnel\PersonnelInterface $personnel */
                 $personnel = \Yii::$app->personnel;
+
+            try {
                 $personnelUser = $personnel->findByAccessToken($accessTokenHash);
+            } catch(\Exception $e) {
+                \Yii::error('Failed to find personnel user for logout: ' . $e->getMessage());
+                return $this->redirect(\Yii::$app->params['uiUrl']);
+            }
 
+            try {
                 $personnel->clearAccessToken($personnelUser->employeeId);
+            } catch(\Exception $e) {
+                \Yii::error('Failed to clear access token for logout: ' . $e->getMessage());
+            }
 
-                /** @var AuthUser $authUser */
-                $authUser = User::createFromPersonnelUser($personnelUser)->getAuthUser();
+            $authUser = User::constructFromPersonnelUser($personnelUser)->getAuthUser();
 
-                /*
-                 * Log user out of IdP
-                 */
-                try {
-                    /** @var AuthnInterface $auth */
-                    $auth = \Yii::$app->auth;
-                    $auth->logout(\Yii::$app->params['uiUrl'], $authUser);
-                } catch (RedirectException $e) {
-                    return $this->redirect($e->getUrl());
-                }
-            } catch (\common\components\personnel\NotFoundException $e) {
-                /*
-                 * Token not found in IdBroker – user already logged out or token expired.
-                 */
+            /*
+             * Log user out of IdP
+             */
+            try {
+                /** @var AuthnInterface $auth */
+                $auth = \Yii::$app->auth;
+                $auth->logout(\Yii::$app->params['uiUrl'], $authUser);
+            } catch (RedirectException $e) {
+                return $this->redirect($e->getUrl());
             }
         }
 

--- a/application/frontend/controllers/AuthController.php
+++ b/application/frontend/controllers/AuthController.php
@@ -117,17 +117,24 @@ class AuthController extends BaseRestController
         $accessToken = $requestCookies->getValue('access_token');
         if ($accessToken !== null) {
             /*
-             * Clear access_token
+             * Remove access_token cookie from browser
              */
-            $accessTokenHash = Utils::getAccessTokenHash($accessToken);
             $responseCookies = \Yii::$app->response->cookies;
             $responseCookies->remove('access_token', true);
-            $user = User::findOne(['access_token' => $accessTokenHash]);
-            if ($user != null) {
-                $user->destroyAccessToken();
+
+            /*
+             * Look up and clear the token in IdBroker, then log out of IdP
+             */
+            try {
+                $accessTokenHash = Utils::getAccessTokenHash($accessToken);
+                /** @var \common\components\personnel\PersonnelInterface $personnel */
+                $personnel = \Yii::$app->personnel;
+                $personnelUser = $personnel->findByAccessToken($accessTokenHash);
+
+                $personnel->clearAccessToken($personnelUser->employeeId);
 
                 /** @var AuthUser $authUser */
-                $authUser = $user->getAuthUser();
+                $authUser = User::createFromPersonnelUser($personnelUser)->getAuthUser();
 
                 /*
                  * Log user out of IdP
@@ -139,6 +146,10 @@ class AuthController extends BaseRestController
                 } catch (RedirectException $e) {
                     return $this->redirect($e->getUrl());
                 }
+            } catch (\common\components\personnel\NotFoundException $e) {
+                /*
+                 * Token not found in IdBroker – user already logged out or token expired.
+                 */
             }
         }
 

--- a/application/frontend/controllers/AuthController.php
+++ b/application/frontend/controllers/AuthController.php
@@ -125,20 +125,20 @@ class AuthController extends BaseRestController
             /*
              * Look up and clear the token in IdBroker, then log out of IdP
              */
-                $accessTokenHash = Utils::getAccessTokenHash($accessToken);
-                /** @var \common\components\personnel\PersonnelInterface $personnel */
-                $personnel = \Yii::$app->personnel;
+            $accessTokenHash = Utils::getAccessTokenHash($accessToken);
+            /** @var \common\components\personnel\PersonnelInterface $personnel */
+            $personnel = \Yii::$app->personnel;
 
             try {
                 $personnelUser = $personnel->findByAccessToken($accessTokenHash);
-            } catch(\Exception $e) {
+            } catch (\Exception $e) {
                 \Yii::error('Failed to find personnel user for logout: ' . $e->getMessage());
                 return $this->redirect(\Yii::$app->params['uiUrl']);
             }
 
             try {
                 $personnel->clearAccessToken($personnelUser->employeeId);
-            } catch(\Exception $e) {
+            } catch (\Exception $e) {
                 \Yii::error('Failed to clear access token for logout: ' . $e->getMessage());
             }
 


### PR DESCRIPTION
[IDP-1967](https://support.gtis.sil.org/issue/IDP-1967) move access token storage to idp-id-broker

---

### Changed
- Access-token flow – update AuthController logout to use IdBroker lookup.

---

### PR Checklist

- [ ] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, etc.)
- [ ] Unit tests created or updated
- [ ] Run `make composershow`
