### PR TITLE
add COMPOSER_ROOT_VERSION to silence message

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -126,6 +126,7 @@ services:
     working_dir: /data
     environment:
       COMPOSER_CACHE_DIR: /composer
+      COMPOSER_ROOT_VERSION: dev-local
     env_file:
       - ./common.env
       - path: ./local.env


### PR DESCRIPTION

### Added
- Added `COMPOSER_ROOT_VERSION` to silence message: "Composer could not detect the root package (sil-org/idp-pw-api) version, defaulting to '1.0.0'. See https://getcomposer.org/root-version"