### PR TITLE
fix the logic for an access token error message

### DIFF
--- a/application/common/components/personnel/IdBroker.php
+++ b/application/common/components/personnel/IdBroker.php
@@ -305,7 +305,9 @@ class IdBroker extends Component implements PersonnelInterface
             return $this->returnPersonnelUserFromResponse('token_hash', '***', $results[0]);
         }
 
-        \Yii::error("More than one user has the same token, found $found users with hash $accessTokenHash");
+        if ($found > 1) {
+            \Yii::error("More than one user has the same token, found $found users with hash $accessTokenHash");
+        }
 
         throw new NotFoundException();
     }


### PR DESCRIPTION

### Fixed
- Fixed the condition for the "More than one user has the same token." error message.

---

### PR Checklist

- [ ] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, openapi.yaml, etc.)
- [ ] Unit tests created or updated
- [ ] Run `make composershow`
