### PR TITLE
remove DB check from site/system-status

### DIFF
--- a/application/frontend/controllers/SiteController.php
+++ b/application/frontend/controllers/SiteController.php
@@ -2,8 +2,6 @@
 
 namespace frontend\controllers;
 
-use common\components\Emailer;
-use Exception;
 use frontend\components\BaseRestController;
 use yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
@@ -71,19 +69,5 @@ class SiteController extends BaseRestController
     /**
      * @throws HttpException
      */
-    public function actionSystemStatus()
-    {
-        /**
-         * Check for DB connection
-         */
-        try {
-            \Yii::$app->db->open();
-        } catch (Exception $e) {
-            throw new HttpException(
-                self::HttpExceptionBadGateway,
-                'Unable to connect to db, error code ' . $e->getCode(),
-                $e->getCode()
-            );
-        }
-    }
+    public function actionSystemStatus() {}
 }


### PR DESCRIPTION
[IDP-1965](https://support.gtis.sil.org/issue/IDP-1965) move data from pw-api to id-broker

---

### Fixed
- the /site/system-status to not fail checking for the database connection.

---

### PR Checklist

- [ ] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, openapi.yaml, etc.)
- [ ] Unit tests created or updated
- [ ] Run `make composershow`
