### PR TITLE
update composer.json to indicate ext-bcmath is required

### DIFF
--- a/application/composer.json
+++ b/application/composer.json
@@ -10,8 +10,9 @@
   ],
   "require": {
     "php": "^8.3",
-    "ext-json": "*",
+    "ext-bcmath": "*",
     "ext-iconv": "*",
+    "ext-json": "*",
     "yiisoft/yii2": "~2.0.15",
     "yiisoft/yii2-swiftmailer": "*",
     "yiisoft/yii2-gii": "*",


### PR DESCRIPTION

### Fixed
- Added ext-bcmath to composer.json since it became required by SimpleSAMLphp in #393 


---

### PR Checklist

- [ ] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, openapi.yaml, etc.)
- [ ] Unit tests created or updated
- [ ] Run `make composershow`
