### PR TITLE
Changed getCookieConfig() visibility to keep it from being run as a test

### DIFF
--- a/application/tests/api/BaseCest.php
+++ b/application/tests/api/BaseCest.php
@@ -1,8 +1,5 @@
 <?php
 
-use tests\api\FixtureHelper;
-use tests\helpers\BrokerUtils;
-
 class BaseCest
 {
     /** @var  tests\api\FixtureHelper */
@@ -23,7 +20,7 @@ class BaseCest
         $this->fixtureHelper->_afterSuite();
     }
 
-    public function getCookieConfig()
+    protected function getCookieConfig()
     {
         return
         [


### PR DESCRIPTION
### Fixed
- Changed `getCookieConfig()` visibility to `protected` to keep it from being run as a test.
- Removed unused imports.