### PR TITLE
Compose cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,11 @@ testapi:
 testintegration:
 	docker compose run --rm integrationtest
 
-api: broker composer
-	docker compose up -d api zxcvbn phpmyadmin brokerpma emailpma
+api: broker composer adminer
+	docker compose up -d api zxcvbn
+
+adminer:
+	docker compose up -d adminer
 
 composer:
 	docker compose run --rm cli composer install

--- a/compose.yaml
+++ b/compose.yaml
@@ -100,14 +100,12 @@ services:
     environment: *mysql_env
     <<: *db_healthcheck
 
-  brokerpma:
-    image: phpmyadmin:5
+  adminer:
+    image: adminer
     ports:
-      - "51158:80"
+      - '51158:80'
     environment:
-      PMA_HOST: broker-db
-      PMA_USER: broker
-      PMA_PASSWORD: broker
+      ADMINER_DEFAULT_SERVER: 'broker-db'
 
   broker:
     image: ghcr.io/sil-org/idp-id-broker:8

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,12 @@ x-db_healthcheck: &db_healthcheck
     timeout: 5s
     retries: 3
 
+x-mysql_env: &mysql_env
+  MYSQL_DATABASE: "db"
+  MYSQL_USER: "user"
+  MYSQL_PASSWORD: "pass"
+  MYSQL_ROOT_PASSWORD: "pass"
+
 services:
 
   api:
@@ -91,11 +97,7 @@ services:
 
   brokerDb:
     image: mariadb:10
-    environment:
-      MYSQL_ROOT_PASSWORD: r00tp@ss!
-      MYSQL_DATABASE: broker
-      MYSQL_USER: broker
-      MYSQL_PASSWORD: broker
+    environment: *mysql_env
     <<: *db_healthcheck
 
   brokerpma:
@@ -124,9 +126,7 @@ services:
       EMAILER_CLASS: \Sil\SilIdBroker\Behat\Context\fakes\FakeEmailer
       IDP_NAME: idp1
       MYSQL_HOST: brokerDb
-      MYSQL_DATABASE: broker
-      MYSQL_USER: broker
-      MYSQL_PASSWORD: broker
+      <<: *mysql_env
       API_ACCESS_KEYS: abc123
       HELP_CENTER_URL: https://example.com/#/help
       PASSWORD_FORGOT_URL: https://example.com/#/forgot

--- a/compose.yaml
+++ b/compose.yaml
@@ -95,7 +95,7 @@ services:
     image: wcjr/zxcvbn-api:1.1.0
     platform: linux/amd64
 
-  brokerDb:
+  broker-db:
     image: mariadb:10
     environment: *mysql_env
     <<: *db_healthcheck
@@ -105,7 +105,7 @@ services:
     ports:
       - "51158:80"
     environment:
-      PMA_HOST: brokerDb
+      PMA_HOST: broker-db
       PMA_USER: broker
       PMA_PASSWORD: broker
 
@@ -115,7 +115,7 @@ services:
     ports:
       - "51154:80"
     depends_on:
-      brokerDb:
+      broker-db:
         condition: service_healthy
     volumes:
       - ./dockerbuild/broker/m381901_235959_insert_test_data.php:/app/console/migrations/m381901_235959_insert_test_data.php
@@ -125,7 +125,7 @@ services:
     environment:
       EMAILER_CLASS: \Sil\SilIdBroker\Behat\Context\fakes\FakeEmailer
       IDP_NAME: idp1
-      MYSQL_HOST: brokerDb
+      MYSQL_HOST: broker-db
       <<: *mysql_env
       API_ACCESS_KEYS: abc123
       HELP_CENTER_URL: https://example.com/#/help

--- a/compose.yaml
+++ b/compose.yaml
@@ -34,6 +34,7 @@ services:
     environment:
       APP_ENV: test
       ID_BROKER_baseUrl: http://broker
+      COMPOSER_ROOT_VERSION: dev-local
     command: ["/data/run-tests-api.sh"]
 
   unittest:
@@ -49,6 +50,7 @@ services:
     environment:
       APP_ENV: test
       ID_BROKER_baseUrl: http://broker
+      COMPOSER_ROOT_VERSION: dev-local
     command: ["/data/run-tests.sh"]
 
   integrationtest:


### PR DESCRIPTION
[IDP-2128](https://support.gtis.sil.org/issue/IDP-2128) Switch IDP over to use Adminer

---

### Changed
- Changed out phpMyAdmin for Adminer.
- Renamed broker-db service to remove uppercase character (DNS case).
- Use YAML block to share common database variables.
- Added COMPOSER_ROOT_VERSION to other containers to silence warning.